### PR TITLE
[ci|build] Add `CPPFLAGS, LDFLAGS`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,8 @@ jobs:
         run: |
           brew install llvm@19
           echo PATH="/opt/homebrew/opt/llvm@19/bin:$PATH" >> $GITHUB_ENV
+          echo "LDFLAGS=-L/opt/homebrew/opt/llvm@19/lib" >> $GITHUB_ENV
+          echo "CPPFLAGS=-I/opt/homebrew/opt/llvm@19/include" >> $GITHUB_ENV
           brew link --overwrite llvm@19
 
       - name: run cmake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           preset: ${{ matrix.preset }}
 
   macos-build:
-    runs-on: macos-latest
+    runs-on: macos-15
     strategy:
       matrix:
         preset: [macos-debug, macos-release]
@@ -127,11 +127,11 @@ jobs:
 
       - name: install clang
         run: |
-          brew install llvm@19
-          echo PATH="/opt/homebrew/opt/llvm@19/bin:$PATH" >> $GITHUB_ENV
-          echo "LDFLAGS=-L/opt/homebrew/opt/llvm@19/lib" >> $GITHUB_ENV
-          echo "CPPFLAGS=-I/opt/homebrew/opt/llvm@19/include" >> $GITHUB_ENV
-          brew link --overwrite llvm@19
+          brew install llvm@20
+          echo PATH="/opt/homebrew/opt/llvm@20/bin:$PATH" >> $GITHUB_ENV
+          echo "LDFLAGS=-L/opt/homebrew/opt/llvm@20/lib" >> $GITHUB_ENV
+          echo "CPPFLAGS=-I/opt/homebrew/opt/llvm@20/include" >> $GITHUB_ENV
+          brew link --overwrite llvm@20
 
       - name: run cmake
         uses: ./.github/workflows/ci-cmake

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -87,7 +87,7 @@
       "cacheVariables": {
         "CMAKE_C_COMPILER": "clang",
         "CMAKE_CXX_COMPILER": "clang++",
-        "CMAKE_CXX_FLAGS": "env{CPPFLAGS}",
+        "CMAKE_CXX_FLAGS": "$env{CPPFLAGS}",
         "CMAKE_EXE_LINKER_FLAGS": "$env{LDFLAGS}"
       },
       "condition": {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -86,7 +86,9 @@
       "installDir": "${sourceDir}/out/install/${presetName}",
       "cacheVariables": {
         "CMAKE_C_COMPILER": "clang",
-        "CMAKE_CXX_COMPILER": "clang++"
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_CXX_FLAGS": "env{CPPFLAGS}",
+        "CMAKE_EXE_LINKER_FLAGS": "$env{LDFLAGS}"
       },
       "condition": {
         "type": "equals",


### PR DESCRIPTION
# CHECK LIST

- [x] Run regression tests
- [ ] Test in local environment

# Current behavior

## Scenario 1

1. Try to compile on macos-build jobs, github actions
2. Failed to compile due to invalid lib path

# Expected behavior

## Scenario 1

1. Try to compile on macos-build jobs, github actions
2. Will be success to compile
