### PR TITLE
[ci] Upgrade macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           preset: ${{ matrix.preset }}
 
   macos-build:
-    runs-on: macos-latest
+    runs-on: macos-15
     strategy:
       matrix:
         preset: [macos-debug, macos-release]


### PR DESCRIPTION
# CHECK LIST

- [x] Run regression tests
- [ ] Test in local environment

# Current behavior

## Scenario 1

1. Try to compile on macos-build jobs, github actions
2. Failed to compile due to invalid lib path

# Expected behavior

## Scenario 1

1. Try to compile on macos-build jobs, github actions
2. Will be success to compile
