### PR TITLE
[ci] Add job condition

### DIFF
--- a/.github/workflows/dev-stage-test-result.yml
+++ b/.github/workflows/dev-stage-test-result.yml
@@ -18,10 +18,14 @@ permissions:
 jobs:
   post-comment:
     runs-on: ubuntu-latest
-    if: >
-      github.event.workflow_run.head_branch == 'dev' || 
-      startsWith(github.event.workflow_run.head_branch, 'release/') && 
+    if: ${{
+      (
+        github.event.workflow_run.head_branch == 'dev' || 
+        startsWith(github.event.workflow_run.head_branch, 'release/') || 
+        startsWith(github.event.workflow_run.head_branch, 'non-release/')
+      ) && 
       github.event.workflow_run.head_ref == ''
+    }}
     steps:
       - name: target environment
         run: |


### PR DESCRIPTION
# Current behavior

## Scenario 1

1. Push commits to non-release branches
2. `post-comment` job was not triggered

# Expected behavior

## Scenario 1

1. Push commits to non-release branches
2. `post-comment` job will be triggered
