### PR TITLE
Non release/2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,13 @@ on:
       - main
       - dev
       - release/*
+      - non-release/*
   pull_request:
     branches:
       - main
       - dev
       - release/*
+      - non-release/*
 
 jobs:
   windows-build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           preset: ${{ matrix.preset }}
 
   macos-build:
-    runs-on: macos-latest
+    runs-on: macos-15
     strategy:
       matrix:
         preset: [macos-debug, macos-release]

--- a/.github/workflows/dev-stage-test-result.yml
+++ b/.github/workflows/dev-stage-test-result.yml
@@ -18,10 +18,14 @@ permissions:
 jobs:
   post-comment:
     runs-on: ubuntu-latest
-    if: >
-      github.event.workflow_run.head_branch == 'dev' || 
-      startsWith(github.event.workflow_run.head_branch, 'release/') && 
+    if: ${{
+      (
+        github.event.workflow_run.head_branch == 'dev' || 
+        startsWith(github.event.workflow_run.head_branch, 'release/') || 
+        startsWith(github.event.workflow_run.head_branch, 'non-release/')
+      ) && 
       github.event.workflow_run.head_ref == ''
+    }}
     steps:
       - name: target environment
         run: |


### PR DESCRIPTION
# Current behavior

## Scenario 1

1. Push commits to non-release branches
2. `ci` workflow was not triggered
3. `post-comment` job was not triggered

## Scenario 2

1. Try to compile on macos-build jobs, github actions
2. Failed to compile due to invalid lib path

# Expected behavior

## Scenario 1

1. Push commits to non-release branches
2. `ci` workflow will be triggered
3. `post-comment` job will be triggered

## Scenario 2

1. Try to compile on macos-build jobs, github actions
2. Will be success to compile
