### PR TITLE
[CI] Use `fail-fast` instead of `continue-on-error`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
   windows-build:
     runs-on: windows-latest
     strategy:
+      fail-fast: false
       matrix:
         preset: [x64-debug, x64-release]
-    continue-on-error: true
 
     steps:
       - name: install cmake & ninja
@@ -57,9 +57,9 @@ jobs:
   linux-build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         preset: [linux-debug, linux-release]
-    continue-on-error: true
 
     steps:
       - name: checkout
@@ -98,9 +98,9 @@ jobs:
   macos-build:
     runs-on: macos-15
     strategy:
+      fail-fast: false
       matrix:
         preset: [macos-debug, macos-release]
-    continue-on-error: true
 
     steps:
       - name: checkout
@@ -137,16 +137,3 @@ jobs:
         uses: ./.github/workflows/ci-cmake
         with:
           preset: ${{ matrix.preset }}
-
-  check-success:
-    runs-on: ubuntu-latest
-    needs: [windows-build, linux-build, macos-build]
-    steps:
-      - name: check success
-        run: |
-          if [[ "${{ needs.windows-build.result }}" != "success" ]] || \
-             [[ "${{ needs.linux-build.result }}" != "success" ]] || \
-             [[ "${{ needs.macos-build.result }}" != "success" ]]; then
-            echo "One or more builds failed."
-            exit 1
-          fi

--- a/.github/workflows/dev-stage-test-result.yml
+++ b/.github/workflows/dev-stage-test-result.yml
@@ -51,12 +51,19 @@ jobs:
           JSON_ARRAY=$(echo "$ISSUE_NUMBERS" | jq -R . | jq -s .)
           echo "issue_numbers=$JSON_ARRAY" >> $GITHUB_OUTPUT
 
-      - name: post comment
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          issue-number: ${{ env.ISSUE_NUMBER }}
-          body: ${{ env.message }}
-
     outputs:
       issue_numbers: ${{ steps.extract_issues.outputs.issue_numbers }}
       message: ${{ steps.set_message.outputs.message }}
+
+  post-comments:
+    runs-on: ubuntu-latest
+    needs: parse-issue-ids
+    strategy:
+      matrix:
+        issue: ${{ fromJson(needs.parse-issue-ids.outputs.issue_numbers) }}
+    steps:
+      - name: post comments
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ matrix.issue }}
+          body: ${{ needs.parse-issue-ids.outputs.message }}

--- a/.github/workflows/dev-stage-test-result.yml
+++ b/.github/workflows/dev-stage-test-result.yml
@@ -16,16 +16,29 @@ permissions:
   issues: write
 
 jobs:
+  set-condition:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.calc_condition.outputs.should_run }}
+    steps:
+      - name: calculate condition
+        id: calc_condition
+        run: |
+          BRANCH="${{ github.event.workflow_run.head_branch }}"
+          REF="${{ github.event.workflow_run.head_ref }}"
+          if [[ "$BRANCH" == "dev" || "$BRANCH" == release/* || "$BRANCH" == non-release/* ]] && [[ "$REF" == "" ]]; then
+            echo "should_run=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_run=false" >> $GITHUB_OUTPUT
+          fi
+
   parse-issue-ids:
     runs-on: ubuntu-latest
-    if: ${{
-      (
-        github.event.workflow_run.head_branch == 'dev' || 
-        startsWith(github.event.workflow_run.head_branch, 'release/') || 
-        startsWith(github.event.workflow_run.head_branch, 'non-release/')
-      ) && 
-      github.event.workflow_run.head_ref == ''
-    }}
+    needs: set-condition
+    if: ${{ needs.set-condition.outputs.should_run == 'true' }}
+    outputs:
+      issue_numbers: ${{ steps.extract_issues.outputs.issue_numbers }}
+      message: ${{ steps.set_message.outputs.message }}
     steps:
       - name: target environment
         run: |
@@ -50,10 +63,6 @@ jobs:
           ISSUE_NUMBERS=$(echo "${{ github.event.workflow_run.head_commit.message }}" | grep -o '#[0-9]\+' | tr -d '#' | sort -u)
           JSON_ARRAY=$(echo "$ISSUE_NUMBERS" | jq -R . | jq -s .)
           echo "issue_numbers=$JSON_ARRAY" >> $GITHUB_OUTPUT
-
-    outputs:
-      issue_numbers: ${{ steps.extract_issues.outputs.issue_numbers }}
-      message: ${{ steps.set_message.outputs.message }}
 
   post-comments:
     runs-on: ubuntu-latest

--- a/.github/workflows/dev-stage-test-result.yml
+++ b/.github/workflows/dev-stage-test-result.yml
@@ -16,7 +16,7 @@ permissions:
   issues: write
 
 jobs:
-  post-comment:
+  parse-issue-ids:
     runs-on: ubuntu-latest
     if: ${{
       (
@@ -36,20 +36,27 @@ jobs:
           fi
 
       - name: set comment message
+        id: set_message
         run: |
           if [ "${{ github.event.workflow_run.conclusion }}" == "success" ]; then
-            echo "message=✅ ${{ env.env }} test completed successfully!" >> $GITHUB_ENV
+            echo "message=✅ ${{ env.env }} test completed successfully!" >> $GITHUB_OUTPUT
           else
-            echo "message=❌ ${{ env.env }} test failed. Please check the details at: https://github.com/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}" >> $GITHUB_ENV
+            echo "message=❌ ${{ env.env }} test failed. Please check the details at: https://github.com/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}" >> $GITHUB_OUTPUT
           fi
 
-      - name: extract issue number from commit message
+      - name: extract issue numbers from commit message
+        id: extract_issues
         run: |
-          ISSUE_NUMBER=$(echo '${{ github.event.workflow_run.head_commit.message }}' | sed -n '3p' | grep -o '#[0-9]*' | tr -d '#')
-          echo "ISSUE_NUMBER=$ISSUE_NUMBER" >> $GITHUB_ENV
+          ISSUE_NUMBERS=$(echo "${{ github.event.workflow_run.head_commit.message }}" | grep -o '#[0-9]\+' | tr -d '#' | sort -u)
+          JSON_ARRAY=$(echo "$ISSUE_NUMBERS" | jq -R . | jq -s .)
+          echo "issue_numbers=$JSON_ARRAY" >> $GITHUB_OUTPUT
 
       - name: post comment
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ env.ISSUE_NUMBER }}
           body: ${{ env.message }}
+
+    outputs:
+      issue_numbers: ${{ steps.extract_issues.outputs.issue_numbers }}
+      message: ${{ steps.set_message.outputs.message }}


### PR DESCRIPTION
# Current behavior

## Scenario 1

1. Some jobs are failed on 'ci' workflow
2. Regarded as success

# Expected behavior

## Scenario 1

1. Some jobs are failed on 'ci' workflow
2. Regarded as fail