### PR TITLE
[ci] Filter by push event

### DIFF
--- a/.github/workflows/dev-stage-test-result.yml
+++ b/.github/workflows/dev-stage-test-result.yml
@@ -24,9 +24,9 @@ jobs:
       - name: calculate condition
         id: calc_condition
         run: |
+          EVENT="${{ github.event.workflow_run.event}}"
           BRANCH="${{ github.event.workflow_run.head_branch }}"
-          REF="${{ github.event.workflow_run.head_ref }}"
-          if [[ "$BRANCH" == "dev" || "$BRANCH" == release/* || "$BRANCH" == non-release/* ]] && [[ "$REF" == "" ]]; then
+          if [[ "$EVENT" == "push" ]] && [[ "$BRANCH" == "dev" || "$BRANCH" == release/* || "$BRANCH" == non-release/* ]]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
           else
             echo "should_run=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
# Current behavior

## Scenario 1

1. `ci` workflow complete when not push event
2. Commenting workflow runned

# Expected behavior

## Scenario 1

1. `ci` workflow complete when not push event
2. Commenting workflow will be filtered