### PR TITLE
[CI] parse commit message from the 2nd line

### DIFF
--- a/.github/workflows/dev-stage-test-result.yml
+++ b/.github/workflows/dev-stage-test-result.yml
@@ -60,7 +60,7 @@ jobs:
       - name: extract issue numbers from commit message
         id: extract_issues
         run: |
-          ISSUE_NUMBERS=$(printf '%s' "${{ github.event.workflow_run.head_commit.message }}" | grep -o '#[0-9]\+' | tr -d '#' | sort -u)
+          ISSUE_NUMBERS=$(printf '%s' "${{ github.event.workflow_run.head_commit.message }}" | tail -n +2 | grep -o '#[0-9]\+' | tr -d '#' | sort -u)
           JSON_ARRAY=$(echo "$ISSUE_NUMBERS" | jq -R . | jq -sc .)
           echo "issue_numbers=$JSON_ARRAY" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
# Current behavior

## Scenario 1

1. Workflow triggered
2. Parse from the first line
3. Try to comment with PR

# Expected behavior

## Scenario 1

1. Workflow triggered
2. Parse from the second line
3. Try to comment without PR